### PR TITLE
feat: automated BlackHole routing, call auto-detection, design pass

### DIFF
--- a/docs/audio-routing.md
+++ b/docs/audio-routing.md
@@ -1,0 +1,82 @@
+# Automated audio routing (Meeting Mode)
+
+This document explains how fluent ai sends your translation into a call so the
+**other person hears only the translation while your original voice stays
+private** — and how the app sets this up for you automatically.
+
+## The goal
+
+```
+you speak ─► fluent ai captures your REAL mic ─► Whisper + translate ─► `say` ─► BlackHole
+                                                                                    │
+                              system default INPUT = BlackHole ◄────────────────────┘
+                                                                                    │
+                                          the call app reads the default input ─────┘ ─► remote party
+```
+
+- The **call app's microphone** is BlackHole, so it transmits our translated
+  TTS — not your voice.
+- fluent ai captures your **real hardware mic explicitly**, so it still hears you
+  even though the system default input is now BlackHole.
+- The system default **output is left untouched**, so you keep hearing the other
+  person normally.
+- You do **not** hear your own translation (by design); use the **Test setup**
+  button to confirm it's flowing.
+
+This works for apps with no microphone picker (WhatsApp, FaceTime) as well as
+those that have one (Zoom, Meet, Teams) — see the per-app note below.
+
+## What the app automates
+
+Implemented in [`fluentai/audio_setup.py`](../fluentai/audio_setup.py), wired
+into Meeting Mode in `gui_app.py`:
+
+1. **Install BlackHole on first use.** If the BlackHole device isn't present,
+   `ensure_blackhole_installed()` downloads the official **signed `.pkg`** and
+   runs it with a single macOS admin authorization (one native password
+   dialog), then restarts `coreaudiod`. No Terminal, no reboot.
+2. **Route on start.** `enter_meeting_routing()` records your current default
+   input, switches the **system default input to BlackHole**, and returns your
+   real mic's index so capture stays on the real mic.
+3. **Restore on stop / quit.** `exit_meeting_routing()` puts your original
+   default input back. This also runs from `on_close()` as a safety net, so the
+   app never leaves your mic hijacked.
+
+### Why one password prompt is unavoidable
+
+BlackHole is a **user-space CoreAudio HAL plugin**, not a kernel/system
+extension — so it does *not* trigger the multi-step "Privacy & Security → Allow"
+flow or a reboot. But macOS still requires admin authorization to add a
+system-wide audio device. That single prompt is the only manual step, it happens
+once, and it's true of any solution (BlackHole, Loopback, a custom driver).
+
+## Verifying it works ("Test setup")
+
+The **Test setup** button runs two checks without needing a real call:
+
+- **Microphone** — records ~2 s from your real mic and confirms signal.
+- **Translation routing** — plays a phrase to BlackHole while recording
+  BlackHole's input (it loops back), confirming the call path works.
+
+If both pass, start Meeting Mode and call.
+
+## Per-app note
+
+| App | What you need to do |
+|---|---|
+| WhatsApp, FaceTime | Nothing — they follow the system default input. |
+| Zoom, Meet, Teams | If you previously **pinned** a specific mic in their settings, set it to **BlackHole 2ch** (or "Same as System"). Otherwise nothing. |
+
+## Platform support
+
+macOS only. `audio_setup.is_macos()` is `False` elsewhere and every routine is a
+safe no-op, so the rest of the app still runs. The CoreAudio / CoreFoundation
+calls use `ctypes` directly (no extra dependency), mirroring
+[`fluentai/meeting_detector.py`](../fluentai/meeting_detector.py).
+
+## Auto-detection
+
+When **Auto-detect calls** is on, `MicMonitor` watches for any app grabbing the
+mic and prompts "Call detected — start live translation?". Accepting runs the
+same routing described above. See the roadmap for the menu-bar agent that will
+make this fully background.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,78 @@
+# fluent ai — design system
+
+The look of the app. The single source of truth in code is
+[`fluentai/ui/theme.py`](../fluentai/ui/theme.py); use its constants and helpers
+rather than hard-coding colors. Direction: **minimalist, Granola-like** — white
+base, generous whitespace, one strong accent, color used with restraint.
+
+## Palette
+
+### Light (main window)
+
+| Token | Hex | Use |
+|---|---|---|
+| `PRIMARY` | `#0A84FF` | Electric blue — primary buttons, active state, the wordmark |
+| `PRIMARY_HOVER` | `#0060DF` | Pressed/hover blue |
+| `ACCENT` | `#00E676` | Electric green — **sparingly**: LIVE dot, success only |
+| `SURFACE` | `#FFFFFF` | Base background |
+| `SURFACE_ALT` | `#F1F4F8` | Subtle panels, secondary buttons |
+| `TEXT` | `#0B0B0F` | High-contrast text |
+| `MUTED` | `#8A94A6` | Secondary text, borders, tentative captions |
+| `DANGER` | `#E5484D` | Stop / destructive |
+| `ON_PRIMARY` | `#FFFFFF` | Text on colored buttons |
+
+### Dark (floating overlay — the in-meeting surface)
+
+| Token | Hex | Use |
+|---|---|---|
+| `DARK_SURFACE` | `#0B0B0F` | Overlay background |
+| `DARK_TEXT` | `#F5F7FA` | Overlay text |
+| `DARK_MUTED` | `#5B6472` | Overlay secondary text |
+
+## Typography
+
+`FONT_FAMILY = "Helvetica Neue"`, via `theme.font(size, weight)`. The wordmark
+**"fluent ai"** is always lowercase with tight tracking, in `PRIMARY`.
+
+## Components
+
+- **Primary button** (`style_primary_button`): filled `PRIMARY`, white text,
+  flat, rounded padding. One per context (e.g. Load model, Record, Start Meeting
+  Mode).
+- **Secondary button** (`style_secondary_button`): quiet `SURFACE_ALT` fill,
+  dark text (Play, Test setup).
+- **Danger button** (`style_danger_button`): filled `DANGER` (Stop Meeting Mode).
+- **LIVE dot**: pulsing `ACCENT` green — the only routine use of green.
+- **Overlay**: dark surface, lowercase wordmark in blue, green LIVE dot,
+  translation in large light text, direction label in muted text.
+
+## Applying the theme
+
+`gui_app.create_ui()` calls, after building widgets:
+
+```python
+theme.apply_theme(self.root)        # base surface + ttk styling
+theme.recolor_surfaces(self.root)   # flip legacy #f0f0f0 frames -> white
+theme.style_primary_button(self.record_btn)   # etc.
+```
+
+`recolor_surfaces()` repaints legacy grey frame/label backgrounds to the brand
+white in one pass, so we get the clean surface without editing every widget.
+
+## Decisions & rationale (delegated design choices)
+
+- **Kept Tkinter** for now (no new dependency); the palette + helpers give a
+  noticeably more refined, consistent look. CustomTkinter / a `pywebview`
+  surface remain options for a deeper redesign later.
+- **Blue is the single brand accent**; green is reserved for "live/active" so it
+  stays meaningful. Stop is red.
+- **White base, lots of whitespace, lowercase wordmark** for the Granola-minimal
+  feel requested.
+- The **overlay is the priority surface** (what you see mid-call), so it got the
+  most deliberate styling.
+
+## Backlog (design)
+
+- Full main-window layout redesign (cards, spacing scale, iconography).
+- Dark mode for the main window (swap `SURFACE`/`TEXT` to the dark column).
+- App + menu-bar icon (electric-blue glyph) and packaged wordmark asset.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,3 +72,18 @@ app + menu-bar icon. Keep whitespace generous (Granola-minimal).
 - Streaming Meeting Mode: live captions (LocalAgreement-2) + per-sentence audio.
 - Low-latency streaming TTS (`say --audio-device`), half/full-duplex handling.
 - Whisper `small` + 700ms segmentation for quality; feedback-loop fix.
+- **Automated audio routing** (`fluentai/audio_setup.py`): one-click BlackHole
+  install (signed pkg, single admin prompt) + CoreAudio default-input switching
+  so the remote party hears only the translation; restored on stop/quit. In-app
+  **Test setup** verification. See [audio-routing.md](audio-routing.md).
+- **Auto-start on call detection**: `MicMonitor` wired into the GUI with a "Call
+  detected — start translation?" prompt and an Auto-detect toggle.
+- **Design pass**: brand palette + helpers (`fluentai/ui/theme.py`), restyled
+  overlay and key buttons, lowercase `fluent ai` wordmark. See [design.md](design.md).
+
+## Backlog (later)
+- **Captions for the remote party** — share the live translation text with the
+  other side (e.g. a shareable browser caption page or screen-share surface).
+  Deferred per product decision; audio routing comes first.
+- Menu-bar agent (`rumps`) + headless pipeline (workstreams 2–3 above).
+- Full main-window redesign + dark mode (palette ready).

--- a/fluentai/audio_setup.py
+++ b/fluentai/audio_setup.py
@@ -1,0 +1,450 @@
+"""Automated audio routing for Meeting Mode (BlackHole-based, macOS).
+
+The product goal is: *you speak, the other party hears only the translation, and
+your original voice stays private.* To make that work in **any** call app — even
+ones with no microphone picker (WhatsApp, FaceTime) — we route audio like this
+while a meeting is active:
+
+    real mic ──► fluent ai (capture) ──► Whisper+translate ──► `say` ──► BlackHole
+                                                                            │
+    system default INPUT = BlackHole ◄──────────────────────────────────────┘
+                                                                            │
+                                              call app reads default input ─┘ ──► remote party
+
+So we set the **system-default input to BlackHole** (the call app then sends our
+translation), while fluent ai captures the user's **real hardware mic
+explicitly** and plays TTS into BlackHole. The system-default *output* is left
+untouched, so the user still hears the other person. On exit we restore the
+original default input.
+
+This module is macOS-only. ``is_macos()`` is False elsewhere and every routine
+degrades to a safe no-op. It speaks to CoreAudio / CoreFoundation directly via
+``ctypes`` (no extra dependency), mirroring the binding style in
+``fluentai/meeting_detector.py``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import logging
+import os
+import platform
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_IS_MACOS = platform.system() == "Darwin"
+
+# Installer sources (used only if BlackHole isn't already present).
+# NOTE: the /blackhole/download/?code=… page is an HTML email-gate, NOT a pkg.
+# The real signed pkg lives under /downloads/ with the version in the name.
+BLACKHOLE_GITHUB_LATEST = (
+    "https://api.github.com/repos/ExistentialAudio/BlackHole/releases/latest"
+)
+BLACKHOLE_PKG_URL_TEMPLATE = (
+    "https://existential.audio/downloads/BlackHole2ch-{version}.pkg"
+)
+BLACKHOLE_FALLBACK_VERSION = "0.6.1"  # used if the latest-version lookup fails
+BLACKHOLE_DEVICE_NAME = "BlackHole"
+# Homebrew caches the (correctly signed) pkg here even when the driver install
+# itself never completed — reuse it instead of re-downloading.
+_CASKROOM_GLOBS = (
+    "/opt/homebrew/Caskroom/blackhole-2ch/*/BlackHole*ch-*.pkg",
+    "/usr/local/Caskroom/blackhole-2ch/*/BlackHole*ch-*.pkg",
+)
+_XAR_MAGIC = b"xar!"  # macOS .pkg files are xar archives
+
+
+def is_macos() -> bool:
+    return _IS_MACOS
+
+
+# ── CoreAudio / CoreFoundation ctypes bindings ───────────────────────────────
+
+
+class _Addr(ctypes.Structure):
+    _fields_ = [
+        ("sel", ctypes.c_uint32),
+        ("scope", ctypes.c_uint32),
+        ("elem", ctypes.c_uint32),
+    ]
+
+
+def _fourcc(code: str) -> int:
+    return int.from_bytes(code.encode("ascii"), "big")
+
+
+_SYSTEM_OBJECT = 1  # kAudioObjectSystemObject
+_PROP_DEVICES = _fourcc("dev#")  # kAudioHardwarePropertyDevices
+_DEFAULT_INPUT = _fourcc("dIn ")  # kAudioHardwarePropertyDefaultInputDevice
+_DEFAULT_OUTPUT = _fourcc("dOut")  # kAudioHardwarePropertyDefaultOutputDevice
+_PROP_NAME = _fourcc("lnam")  # kAudioObjectPropertyName (CFStringRef)
+_SCOPE_GLOBAL = _fourcc("glob")
+_ELEMENT_MAIN = 0
+_CFSTRING_UTF8 = 0x08000100  # kCFStringEncodingUTF8
+
+_ca = None
+_cf = None
+
+
+def _frameworks():
+    """Lazily load CoreAudio + CoreFoundation. Returns (ca, cf) or (None, None)."""
+    global _ca, _cf
+    if _ca is None and _IS_MACOS:
+        try:
+            ca = ctypes.CDLL(ctypes.util.find_library("CoreAudio"))
+            cf = ctypes.CDLL(ctypes.util.find_library("CoreFoundation"))
+
+            ca.AudioObjectGetPropertyData.restype = ctypes.c_int32
+            ca.AudioObjectGetPropertyData.argtypes = [
+                ctypes.c_uint32,
+                ctypes.POINTER(_Addr),
+                ctypes.c_uint32,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint32),
+                ctypes.c_void_p,
+            ]
+            ca.AudioObjectGetPropertyDataSize.restype = ctypes.c_int32
+            ca.AudioObjectGetPropertyDataSize.argtypes = [
+                ctypes.c_uint32,
+                ctypes.POINTER(_Addr),
+                ctypes.c_uint32,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint32),
+            ]
+            ca.AudioObjectSetPropertyData.restype = ctypes.c_int32
+            ca.AudioObjectSetPropertyData.argtypes = [
+                ctypes.c_uint32,
+                ctypes.POINTER(_Addr),
+                ctypes.c_uint32,
+                ctypes.c_void_p,
+                ctypes.c_uint32,
+                ctypes.c_void_p,
+            ]
+
+            cf.CFStringGetCString.restype = ctypes.c_bool
+            cf.CFStringGetCString.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_char_p,
+                ctypes.c_long,
+                ctypes.c_uint32,
+            ]
+            cf.CFRelease.restype = None
+            cf.CFRelease.argtypes = [ctypes.c_void_p]
+
+            _ca, _cf = ca, cf
+        except Exception as e:  # pragma: no cover - load failure / non-macOS
+            logger.warning("CoreAudio/CoreFoundation unavailable: %s", e)
+    return _ca, _cf
+
+
+def _cfstring_to_str(cfstr: ctypes.c_void_p) -> str:
+    _, cf = _frameworks()
+    if not cf or not cfstr:
+        return ""
+    buf = ctypes.create_string_buffer(512)
+    if cf.CFStringGetCString(cfstr, buf, len(buf), _CFSTRING_UTF8):
+        return buf.value.decode("utf-8", "replace")
+    return ""
+
+
+def _get_uint32(object_id: int, selector: int) -> int | None:
+    ca, _ = _frameworks()
+    if ca is None:
+        return None
+    addr = _Addr(selector, _SCOPE_GLOBAL, _ELEMENT_MAIN)
+    out = ctypes.c_uint32(0)
+    size = ctypes.c_uint32(4)
+    status = ca.AudioObjectGetPropertyData(
+        object_id, ctypes.byref(addr), 0, None, ctypes.byref(size), ctypes.byref(out)
+    )
+    return out.value if status == 0 else None
+
+
+def _device_name(device_id: int) -> str:
+    ca, cf = _frameworks()
+    if ca is None or cf is None:
+        return ""
+    addr = _Addr(_PROP_NAME, _SCOPE_GLOBAL, _ELEMENT_MAIN)
+    cfstr = ctypes.c_void_p(0)
+    size = ctypes.c_uint32(ctypes.sizeof(ctypes.c_void_p))
+    status = ca.AudioObjectGetPropertyData(
+        device_id, ctypes.byref(addr), 0, None, ctypes.byref(size), ctypes.byref(cfstr)
+    )
+    if status != 0 or not cfstr:
+        return ""
+    try:
+        return _cfstring_to_str(cfstr)
+    finally:
+        cf.CFRelease(cfstr)
+
+
+def _all_device_ids() -> list[int]:
+    ca, _ = _frameworks()
+    if ca is None:
+        return []
+    addr = _Addr(_PROP_DEVICES, _SCOPE_GLOBAL, _ELEMENT_MAIN)
+    size = ctypes.c_uint32(0)
+    if (
+        ca.AudioObjectGetPropertyDataSize(
+            _SYSTEM_OBJECT, ctypes.byref(addr), 0, None, ctypes.byref(size)
+        )
+        != 0
+    ):
+        return []
+    count = size.value // ctypes.sizeof(ctypes.c_uint32)
+    if count <= 0:
+        return []
+    arr = (ctypes.c_uint32 * count)()
+    if (
+        ca.AudioObjectGetPropertyData(
+            _SYSTEM_OBJECT, ctypes.byref(addr), 0, None, ctypes.byref(size), arr
+        )
+        != 0
+    ):
+        return []
+    return list(arr)
+
+
+def find_device_id_by_name(substring: str) -> int | None:
+    """Return the CoreAudio AudioDeviceID whose name contains *substring*."""
+    needle = substring.lower()
+    for dev_id in _all_device_ids():
+        if needle in _device_name(dev_id).lower():
+            return dev_id
+    return None
+
+
+def get_default_input_id() -> int | None:
+    return _get_uint32(_SYSTEM_OBJECT, _DEFAULT_INPUT)
+
+
+def get_default_output_id() -> int | None:
+    return _get_uint32(_SYSTEM_OBJECT, _DEFAULT_OUTPUT)
+
+
+def _set_default_device(device_id: int, *, selector: int) -> bool:
+    ca, _ = _frameworks()
+    if ca is None:
+        return False
+    addr = _Addr(selector, _SCOPE_GLOBAL, _ELEMENT_MAIN)
+    val = ctypes.c_uint32(device_id)
+    status = ca.AudioObjectSetPropertyData(
+        _SYSTEM_OBJECT, ctypes.byref(addr), 0, None, 4, ctypes.byref(val)
+    )
+    if status != 0:
+        logger.error("Failed to set default device (status=%s)", status)
+    return status == 0
+
+
+def set_default_input_id(device_id: int) -> bool:
+    return _set_default_device(device_id, selector=_DEFAULT_INPUT)
+
+
+def set_default_output_id(device_id: int) -> bool:
+    return _set_default_device(device_id, selector=_DEFAULT_OUTPUT)
+
+
+# ── BlackHole install ────────────────────────────────────────────────────────
+
+
+def is_blackhole_installed() -> bool:
+    """True if a BlackHole audio device is present on the system."""
+    if not _IS_MACOS:
+        return False
+    return find_device_id_by_name(BLACKHOLE_DEVICE_NAME) is not None
+
+
+def _looks_like_pkg(path: str) -> bool:
+    """True if *path* is a real macOS installer (xar archive), not an HTML page."""
+    try:
+        if os.path.getsize(path) < 10_000:
+            return False
+        with open(path, "rb") as fh:
+            return fh.read(4) == _XAR_MAGIC
+    except OSError:
+        return False
+
+
+def _latest_blackhole_version() -> str:
+    """Latest BlackHole version (e.g. '0.6.1'), from GitHub; fallback if offline."""
+    try:
+        import json
+        import urllib.request
+
+        with urllib.request.urlopen(BLACKHOLE_GITHUB_LATEST, timeout=15) as resp:
+            tag = json.load(resp).get("tag_name", "")
+        version = tag.lstrip("vV").strip()
+        if version:
+            return version
+    except Exception as e:
+        logger.warning("BlackHole version lookup failed (%s); using fallback", e)
+    return BLACKHOLE_FALLBACK_VERSION
+
+
+def _resolve_installer_pkg(say) -> str | None:
+    """Return a path to a valid BlackHole .pkg, reusing a cached one if present.
+
+    Homebrew (and a prior interrupted install) leave the correctly-signed pkg in
+    the Caskroom even when the driver itself was never installed — that's the
+    common "it says it's downloaded but doesn't work" case, so we reuse it.
+    """
+    import glob
+
+    for pattern in _CASKROOM_GLOBS:
+        for cached in sorted(glob.glob(pattern), reverse=True):
+            if _looks_like_pkg(cached):
+                say("Using the BlackHole installer already on disk…")
+                return cached
+
+    version = _latest_blackhole_version()
+    url = BLACKHOLE_PKG_URL_TEMPLATE.format(version=version)
+    pkg_path = "/tmp/fluentai_blackhole.pkg"
+    say(f"Downloading BlackHole {version}…")
+    try:
+        subprocess.run(["curl", "-fsSL", "-o", pkg_path, url], check=True, timeout=180)
+    except Exception as e:
+        logger.error("BlackHole download failed: %s", e)
+        return None
+    if not _looks_like_pkg(pkg_path):
+        logger.error("Downloaded BlackHole file is not a valid .pkg (got HTML?)")
+        return None
+    return pkg_path
+
+
+def ensure_blackhole_installed(progress_cb=None) -> bool:
+    """Install BlackHole if missing. Returns True if present afterwards.
+
+    Runs the official signed ``.pkg`` with a single macOS admin authorization
+    (one native password dialog — no Terminal, no Privacy & Security approval,
+    since BlackHole is a user-space CoreAudio HAL plugin, not a kernel/system
+    extension). After this one-time install it persists across reboots. Success
+    is judged by whether the device actually appears, not by exit codes.
+    """
+    if not _IS_MACOS:
+        return False
+    if is_blackhole_installed():
+        return True
+
+    def _say(msg: str):
+        logger.info(msg)
+        if progress_cb:
+            try:
+                progress_cb(msg)
+            except Exception:
+                pass
+
+    pkg_path = _resolve_installer_pkg(_say)
+    if not pkg_path:
+        _say("Couldn't obtain the BlackHole installer.")
+        return False
+
+    _say("Installing BlackHole (one macOS password prompt)…")
+    # One admin authorization via the native dialog; restart coreaudiod so the
+    # new device is visible immediately.
+    script = (
+        f"do shell script \"installer -pkg '{pkg_path}' -target / && "
+        f'killall coreaudiod" with administrator privileges'
+    )
+    try:
+        subprocess.run(["osascript", "-e", script], check=True, timeout=300)
+    except Exception as e:
+        logger.error("BlackHole install failed: %s", e)
+        return False
+    finally:
+        # Only clean up our own temp download, never the Caskroom copy.
+        if pkg_path.startswith("/tmp/"):
+            try:
+                os.remove(pkg_path)
+            except OSError:
+                pass
+
+    ok = is_blackhole_installed()
+    _say("BlackHole installed." if ok else "BlackHole install did not complete.")
+    return ok
+
+
+# ── Meeting routing (enter / exit) ───────────────────────────────────────────
+
+
+@dataclass
+class RoutingState:
+    """What ``enter_meeting_routing`` set up, so ``exit`` can restore it.
+
+    ``real_mic_index`` is the *sounddevice* index of the user's real microphone
+    (a different ID space from CoreAudio device ids) — pass it to
+    ``AudioCaptureThread(device=...)`` so capture stays on the real mic after the
+    system default is switched to BlackHole.
+    """
+
+    real_mic_index: int | None
+    real_mic_name: str
+    saved_default_input_id: int | None
+    blackhole_id: int | None
+    active: bool
+
+
+def _default_input_sounddevice_index() -> tuple[int | None, str]:
+    """The sounddevice index + name of the current default INPUT device."""
+    try:
+        import sounddevice as sd
+
+        info = sd.query_devices(kind="input")
+        name = info.get("name", "") if isinstance(info, dict) else ""
+        for i, dev in enumerate(sd.query_devices()):
+            if dev.get("name") == name and dev.get("max_input_channels", 0) > 0:
+                return i, name
+        return None, name
+    except Exception as e:  # pragma: no cover - no audio backend
+        logger.warning("Could not resolve default input device: %s", e)
+        return None, ""
+
+
+def enter_meeting_routing() -> RoutingState:
+    """Switch the system default input to BlackHole; keep capturing the real mic.
+
+    Captures the real mic's sounddevice index *before* switching. Leaves the
+    default output untouched (so the user still hears the other person). If
+    BlackHole is missing or we're off macOS, returns an inactive state and
+    changes nothing.
+    """
+    if not _IS_MACOS:
+        return RoutingState(None, "", None, None, active=False)
+
+    # Resolve the real mic BEFORE we change anything.
+    real_mic_index, real_mic_name = _default_input_sounddevice_index()
+    saved_input = get_default_input_id()
+    blackhole_id = find_device_id_by_name(BLACKHOLE_DEVICE_NAME)
+
+    if blackhole_id is None:
+        logger.warning("BlackHole not found; routing not applied")
+        return RoutingState(
+            real_mic_index, real_mic_name, saved_input, None, active=False
+        )
+
+    ok = set_default_input_id(blackhole_id)
+    if not ok:
+        return RoutingState(
+            real_mic_index, real_mic_name, saved_input, blackhole_id, active=False
+        )
+
+    logger.info(
+        "Routing active: default input -> BlackHole; capturing real mic '%s' (idx %s)",
+        real_mic_name,
+        real_mic_index,
+    )
+    return RoutingState(
+        real_mic_index, real_mic_name, saved_input, blackhole_id, active=True
+    )
+
+
+def exit_meeting_routing(state: RoutingState | None) -> None:
+    """Restore the system default input captured by ``enter_meeting_routing``."""
+    if not state or not state.active or not _IS_MACOS:
+        return
+    if state.saved_default_input_id is not None:
+        if set_default_input_id(state.saved_default_input_id):
+            logger.info("Routing restored: default input -> '%s'", state.real_mic_name)
+    state.active = False

--- a/fluentai/ui/meeting_overlay.py
+++ b/fluentai/ui/meeting_overlay.py
@@ -1,10 +1,17 @@
 """Floating always-on-top overlay shown during Meeting Mode.
 
 Extracted from ``gui_app.py`` as a self-contained widget so it can be reused
-and tested independently of the main ``FluentAIGUI`` window.
+and tested independently of the main ``FluentAIGUI`` window. Styled with the
+fluent ai design system (see ``fluentai/ui/theme.py``).
 """
 
 import tkinter as tk
+
+from fluentai.ui import theme
+
+_BG = theme.DARK_SURFACE
+_TEXT = theme.DARK_TEXT
+_MUTED = theme.DARK_MUTED
 
 
 class MeetingOverlay:
@@ -14,24 +21,24 @@ class MeetingOverlay:
         self.win = tk.Toplevel(root)
         self.win.overrideredirect(True)
         self.win.attributes("-topmost", True)
-        self.win.attributes("-alpha", 0.92)
-        self.win.geometry("320x90+80+80")
-        self.win.configure(bg="#1a1a2e")
+        self.win.attributes("-alpha", 0.96)
+        self.win.geometry("340x104+80+80")
+        self.win.configure(bg=_BG)
 
         # Drag state
         self._drag_x = 0
         self._drag_y = 0
 
-        # ── Header row: drag handle + direction label ──
-        header = tk.Frame(self.win, bg="#1a1a2e")
-        header.pack(fill=tk.X, padx=8, pady=(6, 2))
+        # ── Header row: drag handle + LIVE dot + wordmark + direction ──
+        header = tk.Frame(self.win, bg=_BG)
+        header.pack(fill=tk.X, padx=14, pady=(10, 2))
 
         drag_handle = tk.Label(
             header,
-            text="≡",
-            font=("Arial", 12),
-            bg="#1a1a2e",
-            fg="#555577",
+            text="⠿",
+            font=theme.font(12),
+            bg=_BG,
+            fg=_MUTED,
             cursor="fleur",
         )
         drag_handle.pack(side=tk.LEFT)
@@ -39,30 +46,38 @@ class MeetingOverlay:
         drag_handle.bind("<B1-Motion>", self._on_drag_motion)
 
         self._dot_label = tk.Label(
-            header, text="●", font=("Arial", 10), bg="#1a1a2e", fg="#27ae60"
+            header, text="●", font=theme.font(10), bg=_BG, fg=theme.ACCENT
         )
-        self._dot_label.pack(side=tk.LEFT, padx=(6, 4))
+        self._dot_label.pack(side=tk.LEFT, padx=(8, 4))
+
+        tk.Label(
+            header,
+            text="fluent ai",
+            font=theme.font(11, "bold"),
+            bg=_BG,
+            fg=theme.PRIMARY,
+        ).pack(side=tk.LEFT)
 
         tk.Label(
             header,
             text=direction_text,
-            font=("Arial", 10, "bold"),
-            bg="#1a1a2e",
-            fg="#ecf0f1",
-        ).pack(side=tk.LEFT)
+            font=theme.font(10),
+            bg=_BG,
+            fg=_MUTED,
+        ).pack(side=tk.RIGHT)
 
         # ── Translation text ──
         self._text_label = tk.Label(
             self.win,
-            text="Waiting for speech...",
-            font=("Arial", 10),
-            bg="#1a1a2e",
-            fg="#27ae60",
-            wraplength=300,
+            text="Waiting for speech…",
+            font=theme.font(13),
+            bg=_BG,
+            fg=_TEXT,
+            wraplength=312,
             justify=tk.LEFT,
             anchor=tk.W,
         )
-        self._text_label.pack(fill=tk.X, padx=12, pady=(0, 6))
+        self._text_label.pack(fill=tk.BOTH, expand=True, padx=14, pady=(2, 12))
 
         # Start pulsing dot animation
         self._dot_visible = True
@@ -72,7 +87,7 @@ class MeetingOverlay:
         if not self.win.winfo_exists():
             return
         self._dot_visible = not self._dot_visible
-        color = "#27ae60" if self._dot_visible else "#1a1a2e"
+        color = theme.ACCENT if self._dot_visible else _BG
         self._dot_label.config(fg=color)
         self.win.after(600, self._animate_dot)
 
@@ -87,7 +102,7 @@ class MeetingOverlay:
 
     def update_text(self, text: str):
         if self.win.winfo_exists():
-            display = text[:50] + "…" if len(text) > 50 else text
+            display = text[:80] + "…" if len(text) > 80 else text
             self._text_label.config(text=display)
 
     def close(self):

--- a/fluentai/ui/theme.py
+++ b/fluentai/ui/theme.py
@@ -1,0 +1,138 @@
+"""fluent ai design system — brand palette, fonts, and Tk/ttk theming helpers.
+
+A single source of truth for the look of the app so the GUI and the floating
+overlay stay consistent. Minimalist / Granola-like: white base, generous
+whitespace, electric blue for primary actions, electric green used sparingly for
+"live"/success only. See ``docs/design.md`` for the rationale and usage rules.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+# ── Light palette (main window) ──────────────────────────────────────────────
+PRIMARY = "#0A84FF"  # electric blue — primary buttons, active state, wordmark
+PRIMARY_HOVER = "#0060DF"  # blue, pressed/hover
+ACCENT = "#00E676"  # electric green — sparingly: LIVE dot, success
+SURFACE = "#FFFFFF"  # base background
+SURFACE_ALT = "#F1F4F8"  # subtle panels / secondary buttons
+TEXT = "#0B0B0F"  # high-contrast text
+MUTED = "#8A94A6"  # secondary text, borders, tentative captions
+DANGER = "#E5484D"  # stop / destructive
+ON_PRIMARY = "#FFFFFF"  # text on colored buttons
+
+# ── Dark palette (floating overlay — the in-meeting surface) ─────────────────
+DARK_SURFACE = "#0B0B0F"
+DARK_TEXT = "#F5F7FA"
+DARK_MUTED = "#5B6472"
+
+FONT_FAMILY = "Helvetica Neue"  # clean macOS system-ish sans
+
+
+def font(size: int, weight: str = "normal") -> tuple[str, int, str]:
+    """A palette font tuple, e.g. ``font(11, "bold")``."""
+    return (FONT_FAMILY, size, weight)
+
+
+def apply_theme(root: tk.Misc) -> ttk.Style:
+    """Set the base surface + ttk widget styling. Returns the configured Style."""
+    try:
+        root.configure(bg=SURFACE)
+    except tk.TclError:
+        pass
+
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")  # most themeable across platforms
+    except tk.TclError:
+        pass
+
+    style.configure(
+        "Fluent.TCombobox",
+        fieldbackground=SURFACE,
+        background=SURFACE_ALT,
+        foreground=TEXT,
+        arrowcolor=TEXT,
+        bordercolor=MUTED,
+        relief="flat",
+    )
+    style.configure(
+        "Fluent.TCheckbutton",
+        background=SURFACE,
+        foreground=MUTED,
+        focuscolor=SURFACE,
+    )
+    return style
+
+
+def style_primary_button(btn: tk.Button) -> None:
+    """Electric-blue filled button for the main action."""
+    btn.configure(
+        bg=PRIMARY,
+        fg=ON_PRIMARY,
+        activebackground=PRIMARY_HOVER,
+        activeforeground=ON_PRIMARY,
+        relief=tk.FLAT,
+        bd=0,
+        highlightthickness=0,
+        font=font(11, "bold"),
+        padx=16,
+        pady=8,
+        cursor="hand2",
+    )
+
+
+def style_secondary_button(btn: tk.Button) -> None:
+    """Quiet neutral button for secondary actions."""
+    btn.configure(
+        bg=SURFACE_ALT,
+        fg=TEXT,
+        activebackground="#E2E7EF",
+        activeforeground=TEXT,
+        relief=tk.FLAT,
+        bd=0,
+        highlightthickness=0,
+        font=font(10),
+        padx=10,
+        pady=6,
+        cursor="hand2",
+    )
+
+
+def style_danger_button(btn: tk.Button) -> None:
+    """Filled red button for stop/destructive actions."""
+    btn.configure(
+        bg=DANGER,
+        fg=ON_PRIMARY,
+        activebackground="#C93C40",
+        activeforeground=ON_PRIMARY,
+        relief=tk.FLAT,
+        bd=0,
+        highlightthickness=0,
+        font=font(11, "bold"),
+        padx=16,
+        pady=8,
+        cursor="hand2",
+    )
+
+
+def recolor_surfaces(
+    widget: tk.Misc, old: tuple[str, ...] = ("#f0f0f0",), new: str = SURFACE
+) -> None:
+    """Recursively repaint legacy frame/label backgrounds onto the new surface.
+
+    Lets us flip the old grey base to the brand white without editing every
+    widget literal. Only touches background of layout/text widgets; buttons,
+    comboboxes and text areas are left to their explicit styling.
+    """
+    classes = (tk.Frame, tk.LabelFrame, tk.Label, tk.Checkbutton, tk.Canvas)
+    try:
+        if isinstance(widget, classes) and str(widget.cget("bg")) in old:
+            widget.configure(bg=new)
+            if isinstance(widget, tk.Checkbutton):
+                widget.configure(activebackground=new, selectcolor=SURFACE_ALT)
+    except tk.TclError:
+        pass
+    for child in widget.winfo_children():
+        recolor_surfaces(child, old, new)

--- a/gui_app.py
+++ b/gui_app.py
@@ -12,14 +12,17 @@ import sounddevice as sd
 import speech_recognition as sr
 
 from audio_capture_thread import AudioCaptureThread
+from fluentai import audio_setup
 from fluentai.app_controller import TranslationController
 from fluentai.audio_utils import apply_automatic_gain_control, normalize_audio_rms
 from fluentai.blackhole_reproduction_thread import BlackHoleReproductionThread
+from fluentai.meeting_detector import MicMonitor
 from fluentai.meeting_pipeline import MeetingSpeakThread
 from fluentai.model_loader import LazyModelLoader
 from fluentai.streaming_asr import StreamingTranscriber
 from fluentai.transcription import transcribe_long_audio
-from fluentai.tts_engine import synthesize_to_numpy
+from fluentai.tts_engine import speak_to_device, synthesize_to_numpy
+from fluentai.ui import theme
 from fluentai.ui.meeting_overlay import MeetingOverlay
 from silence_detector import (
     SilenceDetectorIntegration,
@@ -119,12 +122,24 @@ class FluentAIGUI:
         self.meeting_status_text = tk.StringVar(value="Stopped")
         self._meeting_device_list: list[dict] = []
         self._meeting_overlay: MeetingOverlay | None = None
+        # Audio routing applied while a meeting is active (restored on stop/close).
+        self.meeting_routing_state: audio_setup.RoutingState | None = None
+
+        # Mic-in-use auto-detection (Granola-style "call detected" prompt).
+        self.auto_detect_var = tk.BooleanVar(value=True)
+        self.mic_monitor: MicMonitor | None = None
+        # Suppress repeated prompts during one ongoing call (reset on call end).
+        self._call_prompt_suppressed = False
 
         # Crear la interfaz
         self.create_ui()
 
         # Window close handler
         self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+
+        # Start watching for calls (mic-in-use) if enabled.
+        if self.auto_detect_var.get():
+            self._start_mic_monitor()
 
         # Iniciar el monitoreo de la cola de mensajes
         self.check_message_queue()
@@ -144,19 +159,19 @@ class FluentAIGUI:
 
         title_label = tk.Label(
             title_frame,
-            text="🌍 Fluent AI Translator",
-            font=("Arial", 24, "bold"),
+            text="fluent ai",
+            font=theme.font(28, "bold"),
             bg="#f0f0f0",
-            fg="#2c3e50",
+            fg=theme.PRIMARY,
         )
         title_label.pack()
 
         subtitle_label = tk.Label(
             title_frame,
             text="Español • English • Deutsch • Français",
-            font=("Arial", 14),
+            font=theme.font(13),
             bg="#f0f0f0",
-            fg="#7f8c8d",
+            fg=theme.MUTED,
         )
         subtitle_label.pack()
 
@@ -298,6 +313,17 @@ class FluentAIGUI:
 
         self._build_meeting_panel()
         self._build_status_bar()
+
+        # ── Apply the fluent ai design system ──
+        theme.apply_theme(self.root)
+        # Flip the legacy grey base to the brand white surface in one pass.
+        theme.recolor_surfaces(self.root)
+        # Brand the key action buttons.
+        theme.style_primary_button(self.load_models_btn)
+        theme.style_primary_button(self.record_btn)
+        theme.style_secondary_button(self.play_btn)
+        theme.style_secondary_button(self.meeting_test_btn)
+        theme.style_primary_button(self.meeting_toggle_btn)
 
         # Inicializar la actualización del medidor de micrófono
         self.update_mic_level_display()
@@ -464,6 +490,32 @@ class FluentAIGUI:
         )
         setup_link.pack(side=tk.LEFT)
         setup_link.bind("<Button-1>", lambda _e: self._show_meeting_setup())
+
+        self.meeting_test_btn = tk.Button(
+            meeting_row2,
+            text="Test setup",
+            command=self._test_meeting_setup,
+            font=("Arial", 9),
+            bg="#ecf0f1",
+            fg="#2c3e50",
+            padx=8,
+            pady=2,
+            relief=tk.FLAT,
+        )
+        self.meeting_test_btn.pack(side=tk.LEFT, padx=(12, 0))
+
+        self.auto_detect_check = tk.Checkbutton(
+            meeting_row2,
+            text="Auto-detect calls",
+            variable=self.auto_detect_var,
+            command=self._toggle_auto_detect,
+            font=("Arial", 9),
+            bg="#f0f0f0",
+            fg="#555555",
+            activebackground="#f0f0f0",
+            selectcolor="#f0f0f0",
+        )
+        self.auto_detect_check.pack(side=tk.LEFT, padx=(12, 0))
 
         self.meeting_status_label = tk.Label(
             meeting_row2,
@@ -1345,12 +1397,26 @@ class FluentAIGUI:
             self.start_meeting_mode()
 
     def start_meeting_mode(self):
+        src_lang, dst_lang = self.get_source_and_target_from_direction()
+
+        # Automated audio setup (macOS): make sure BlackHole exists, route the
+        # system default input to it so the call sends our translation, and
+        # capture the user's real mic explicitly. Restored on stop/close.
+        capture_device = None
+        if audio_setup.is_macos():
+            if not self._ensure_blackhole_ready():
+                return  # user declined or install failed
+            self._refresh_output_devices()  # BlackHole now present -> auto-selected
+            self.meeting_routing_state = audio_setup.enter_meeting_routing()
+            capture_device = self.meeting_routing_state.real_mic_index
+
         device_index = self._selected_output_device_index()
         if device_index is None:
             messagebox.showerror("Meeting Mode", "No output device selected.")
+            audio_setup.exit_meeting_routing(self.meeting_routing_state)
+            self.meeting_routing_state = None
             return
 
-        src_lang, dst_lang = self.get_source_and_target_from_direction()
         device_name = self.meeting_output_device_var.get()
 
         # A virtual output (BlackHole) can't feed back into the mic, so we can
@@ -1370,6 +1436,10 @@ class FluentAIGUI:
 
         self.meeting_capture_thread = AudioCaptureThread(
             asr_queue=self.meeting_asr_queue,
+            # Capture the real mic explicitly: the system default input is now
+            # BlackHole (so the call carries our translation), so default
+            # capture would record silence.
+            device=capture_device,
             silence_threshold_ms=700,
             mute_event=mute_event,
             # Emit growing snapshots so captions stream as you speak.
@@ -1411,7 +1481,9 @@ class FluentAIGUI:
         self.translated_text.delete(1.0, tk.END)
 
         # Update UI
-        self.meeting_toggle_btn.config(text="■ Stop Meeting Mode", bg="#e74c3c")
+        self.meeting_toggle_btn.config(
+            text="■ Stop Meeting Mode", bg=theme.DANGER, activebackground="#C93C40"
+        )
         if is_virtual:
             self.meeting_status_text.set(
                 f"LIVE | {self._meeting_direction_label} to {device_name}"
@@ -1420,7 +1492,7 @@ class FluentAIGUI:
             self.meeting_status_text.set(
                 f"LIVE | {self._meeting_direction_label} | ⚠ use headphones (echo risk)"
             )
-        self.meeting_status_label.config(fg="#27ae60")
+        self.meeting_status_label.config(fg=theme.ACCENT)
         self.record_btn.config(state=tk.DISABLED)
         self.direction_combo.config(state="disabled")
 
@@ -1443,15 +1515,23 @@ class FluentAIGUI:
         self.meeting_speak_queue = None
         self.meeting_mode_active = False
 
+        # Restore the system default input device we switched to BlackHole.
+        audio_setup.exit_meeting_routing(self.meeting_routing_state)
+        self.meeting_routing_state = None
+
         # Close overlay
         if self._meeting_overlay:
             self._meeting_overlay.close()
             self._meeting_overlay = None
 
         # Restore UI
-        self.meeting_toggle_btn.config(text="● Start Meeting Mode", bg="#27ae60")
+        self.meeting_toggle_btn.config(
+            text="● Start Meeting Mode",
+            bg=theme.PRIMARY,
+            activebackground=theme.PRIMARY_HOVER,
+        )
         self.meeting_status_text.set("Stopped")
-        self.meeting_status_label.config(fg="#95a5a6")
+        self.meeting_status_label.config(fg=theme.MUTED)
         self.record_btn.config(state=tk.NORMAL)
         self.direction_combo.config(state="readonly")
 
@@ -1482,27 +1562,205 @@ class FluentAIGUI:
                 and self._meeting_overlay.update_text(translated),
             )
 
+    # ── Mic-in-use auto-detection ────────────────────────────────────────────
+
+    def _start_mic_monitor(self):
+        """Begin watching for calls (any app capturing the mic)."""
+        if self.mic_monitor is not None:
+            return
+        self.mic_monitor = MicMonitor(
+            on_call_started=self._on_call_started_bg,
+            on_call_ended=self._on_call_ended_bg,
+        )
+        self.mic_monitor.start()
+
+    def _stop_mic_monitor(self):
+        if self.mic_monitor is not None:
+            self.mic_monitor.stop()
+            self.mic_monitor = None
+
+    def _toggle_auto_detect(self):
+        if self.auto_detect_var.get():
+            self._start_mic_monitor()
+        else:
+            self._stop_mic_monitor()
+
+    def _on_call_started_bg(self):
+        # Runs on the monitor thread — marshal to the Tk main thread.
+        self.root.after(0, self._on_call_detected)
+
+    def _on_call_ended_bg(self):
+        # A new call may prompt again once this one ends.
+        self.root.after(0, lambda: setattr(self, "_call_prompt_suppressed", False))
+
+    def _on_call_detected(self):
+        """Prompt to start translation when a call is detected (main thread)."""
+        if (
+            not self.auto_detect_var.get()
+            or self.meeting_mode_active
+            or self._call_prompt_suppressed
+        ):
+            return
+        # One prompt per call; don't nag if they dismiss or while translating.
+        self._call_prompt_suppressed = True
+        if messagebox.askyesno(
+            "Call detected",
+            "A call just started. Start live translation now?",
+        ):
+            self.start_meeting_mode()
+
+    def _sounddevice_input_index(self, substring: str) -> int | None:
+        """sounddevice index of the first input device matching *substring*."""
+        needle = substring.lower()
+        for i, dev in enumerate(sd.query_devices()):
+            if needle in dev.get("name", "").lower() and (
+                dev.get("max_input_channels", 0) > 0
+            ):
+                return i
+        return None
+
+    @staticmethod
+    def _rms(samples: np.ndarray) -> float:
+        if samples.size == 0:
+            return 0.0
+        return float(np.sqrt(np.mean(samples.astype(np.float32) ** 2)))
+
+    def _test_meeting_setup(self):
+        """Verify the mic and BlackHole routing without needing a real call.
+
+        1. Mic check: record the real mic and confirm we get signal.
+        2. Routing check: play a phrase to BlackHole while recording BlackHole's
+           input (it loops back), confirming the call path TTS -> BlackHole works.
+        """
+        if audio_setup.is_macos() and not audio_setup.is_blackhole_installed():
+            if not self._ensure_blackhole_ready():
+                return
+
+        results = []
+
+        # 1. Microphone
+        try:
+            mic_idx, mic_name = audio_setup._default_input_sounddevice_index()
+            self.meeting_status_text.set("Testing mic — speak now…")
+            self.root.update_idletasks()
+            rec = sd.rec(
+                int(2 * 16000),
+                samplerate=16000,
+                channels=1,
+                device=mic_idx,
+                dtype="float32",
+            )
+            sd.wait()
+            ok = self._rms(rec) > 0.005
+            results.append(
+                f"{'✅' if ok else '⚠️'} Microphone ({mic_name or 'default'}): "
+                + ("signal detected" if ok else "very quiet — speak up / check input")
+            )
+        except Exception as e:
+            results.append(f"❌ Microphone test failed: {e}")
+
+        # 2. BlackHole routing (loopback)
+        try:
+            bh_idx = self._sounddevice_input_index(audio_setup.BLACKHOLE_DEVICE_NAME)
+            if bh_idx is None:
+                results.append(
+                    "❌ BlackHole not found — install it first (Set up audio)."
+                )
+            else:
+                self.meeting_status_text.set("Testing routing…")
+                self.root.update_idletasks()
+                speak_to_device(
+                    "Testing fluent A I routing.",
+                    "en",
+                    device_name=audio_setup.BLACKHOLE_DEVICE_NAME,
+                    blocking=False,
+                )
+                rec = sd.rec(
+                    int(2.5 * 44100),
+                    samplerate=44100,
+                    channels=1,
+                    device=bh_idx,
+                    dtype="float32",
+                )
+                sd.wait()
+                ok = self._rms(rec) > 0.005
+                results.append(
+                    f"{'✅' if ok else '❌'} Translation routing (BlackHole): "
+                    + (
+                        "audio is flowing into the call path"
+                        if ok
+                        else "no audio detected"
+                    )
+                )
+        except Exception as e:
+            results.append(f"❌ Routing test failed: {e}")
+
+        self.meeting_status_text.set("Stopped")
+        messagebox.showinfo(
+            "Test setup",
+            "\n\n".join(results)
+            + "\n\nIf both pass, you're ready — start Meeting Mode and call.",
+        )
+
+    def _ensure_blackhole_ready(self) -> bool:
+        """Make sure BlackHole is installed; offer a one-click install if not.
+
+        Returns True if BlackHole is available and Meeting Mode can proceed.
+        """
+        if audio_setup.is_blackhole_installed():
+            return True
+        proceed = messagebox.askyesno(
+            "Set up audio (one time)",
+            "Fluent AI needs the free BlackHole audio device to send your "
+            "translation into calls.\n\n"
+            "Install it now? macOS will ask for your password once — "
+            "no Terminal and no reboot. It just works from then on.",
+        )
+        if not proceed:
+            return False
+
+        self.meeting_status_text.set("Installing BlackHole…")
+        self.root.update_idletasks()
+
+        def _progress(msg: str):
+            self.meeting_status_text.set(msg)
+            self.root.update_idletasks()
+
+        ok = audio_setup.ensure_blackhole_installed(progress_cb=_progress)
+        if not ok:
+            messagebox.showerror(
+                "Set up audio",
+                "BlackHole installation didn't complete.\n\n"
+                "You can install it manually (see setup instructions) "
+                "and try again.",
+            )
+            self.meeting_status_text.set("Stopped")
+            return False
+        return True
+
     def _show_meeting_setup(self):
         messagebox.showinfo(
-            "Meeting Mode Setup (one-time)",
-            "1. Install BlackHole 2ch:\n"
-            "   brew install blackhole-2ch\n"
-            "   (or download from existential.audio)\n\n"
-            "2. In your meeting app (Zoom / Meet / Teams):\n"
-            "   Settings → Audio → Microphone → BlackHole 2ch\n\n"
-            "3. In Fluent AI:\n"
-            "   - Select BlackHole 2ch as output\n"
-            "   - Choose your translation direction\n"
-            "   - Click Start Meeting Mode\n\n"
-            "4. Speak normally in the source language.\n"
-            "   Meeting participants hear your translation.\n\n"
-            "Note: Your real mic is captured by Fluent AI only.\n"
-            "      The meeting app sees BlackHole as your mic.",
+            "Meeting Mode Setup",
+            "Fluent AI sets this up for you automatically:\n\n"
+            "• BlackHole (the audio bridge) is installed on first use\n"
+            "  with one password prompt.\n"
+            "• While Meeting Mode is on, your call's microphone is\n"
+            "  switched to BlackHole and restored when you stop.\n"
+            "• Your real mic is captured by Fluent AI only — the other\n"
+            "  side hears just your translation.\n\n"
+            "Zoom / Teams only: if you previously picked a specific mic\n"
+            "in their settings, set it to 'BlackHole 2ch' (or 'Same as\n"
+            "System'). Apps like WhatsApp / FaceTime need no changes.\n\n"
+            "Then: choose your direction and click Start Meeting Mode.",
         )
 
     def on_close(self):
+        self._stop_mic_monitor()
         if self.meeting_mode_active:
             self.stop_meeting_mode()
+        # Safety net: never leave the user's default mic switched to BlackHole.
+        audio_setup.exit_meeting_routing(self.meeting_routing_state)
+        self.meeting_routing_state = None
         self.root.destroy()
 
 

--- a/tests/test_audio_setup.py
+++ b/tests/test_audio_setup.py
@@ -1,0 +1,89 @@
+"""Tests for fluentai.audio_setup (BlackHole install + CoreAudio routing).
+
+CoreAudio is mocked so these run deterministically on any platform/CI.
+"""
+
+from fluentai import audio_setup
+
+
+def test_find_device_id_by_name(monkeypatch):
+    names = {1: "MacBook Pro Microphone", 2: "BlackHole 2ch", 3: "Speakers"}
+    monkeypatch.setattr(audio_setup, "_all_device_ids", lambda: list(names))
+    monkeypatch.setattr(audio_setup, "_device_name", lambda d: names[d])
+
+    assert audio_setup.find_device_id_by_name("BlackHole") == 2
+    assert audio_setup.find_device_id_by_name("blackhole") == 2  # case-insensitive
+    assert audio_setup.find_device_id_by_name("Nonexistent") is None
+
+
+def test_off_macos_is_safe(monkeypatch):
+    monkeypatch.setattr(audio_setup, "_IS_MACOS", False)
+    assert audio_setup.is_blackhole_installed() is False
+    assert audio_setup.ensure_blackhole_installed() is False
+
+    state = audio_setup.enter_meeting_routing()
+    assert state.active is False
+    # Restoring an inactive/None state must never raise.
+    audio_setup.exit_meeting_routing(state)
+    audio_setup.exit_meeting_routing(None)
+
+
+def test_enter_routing_inactive_without_blackhole(monkeypatch):
+    monkeypatch.setattr(audio_setup, "_IS_MACOS", True)
+    monkeypatch.setattr(
+        audio_setup, "_default_input_sounddevice_index", lambda: (1, "Mic")
+    )
+    monkeypatch.setattr(audio_setup, "get_default_input_id", lambda: 89)
+    monkeypatch.setattr(audio_setup, "find_device_id_by_name", lambda s: None)
+
+    state = audio_setup.enter_meeting_routing()
+
+    assert state.active is False  # no BlackHole -> don't touch the system
+    assert state.real_mic_index == 1
+    assert state.blackhole_id is None
+
+
+def test_enter_switches_to_blackhole_and_exit_restores(monkeypatch):
+    monkeypatch.setattr(audio_setup, "_IS_MACOS", True)
+    monkeypatch.setattr(
+        audio_setup, "_default_input_sounddevice_index", lambda: (1, "Mic")
+    )
+    monkeypatch.setattr(audio_setup, "get_default_input_id", lambda: 89)
+    monkeypatch.setattr(audio_setup, "find_device_id_by_name", lambda s: 42)
+
+    switched = []
+    monkeypatch.setattr(
+        audio_setup,
+        "set_default_input_id",
+        lambda dev: (switched.append(dev) or True),
+    )
+
+    state = audio_setup.enter_meeting_routing()
+    assert state.active is True
+    assert state.blackhole_id == 42
+    assert state.real_mic_index == 1
+    assert switched == [42]  # default input -> BlackHole
+
+    audio_setup.exit_meeting_routing(state)
+    assert switched == [42, 89]  # restored to the original mic
+    assert state.active is False
+
+
+def test_ensure_installed_is_idempotent_when_present(monkeypatch):
+    monkeypatch.setattr(audio_setup, "_IS_MACOS", True)
+    monkeypatch.setattr(audio_setup, "is_blackhole_installed", lambda: True)
+    # Should short-circuit without attempting any download/install.
+    assert audio_setup.ensure_blackhole_installed() is True
+
+
+def test_looks_like_pkg_rejects_html_and_accepts_xar(tmp_path):
+    # The original bug: an email-gate HTML page was treated as a .pkg.
+    html = tmp_path / "page.html"
+    html.write_bytes(b"<html><head><title>Download</title></head></html>" * 500)
+    assert audio_setup._looks_like_pkg(str(html)) is False
+
+    pkg = tmp_path / "BlackHole.pkg"
+    pkg.write_bytes(b"xar!" + b"\x00" * 20_000)  # xar magic + bulk
+    assert audio_setup._looks_like_pkg(str(pkg)) is True
+
+    assert audio_setup._looks_like_pkg(str(tmp_path / "missing.pkg")) is False


### PR DESCRIPTION
Make the core promise actually work — you speak, the other party hears only your translation, your original voice stays private — and remove the manual audio setup.

Audio routing (fluentai/audio_setup.py):
- One-click BlackHole install: reuses the already-downloaded Caskroom pkg when present, else downloads the real signed pkg (version via GitHub), validates the xar magic so an HTML email-gate page can't be mistaken for an installer, and runs it with a single admin prompt. Success judged by the device appearing, not exit codes.
- CoreAudio default-device switching via ctypes (no new dep): on Meeting Mode start, switch the system default input to BlackHole so the call transmits our translation while we capture the real mic explicitly; output left untouched so the user still hears the other person. Restored on stop and on window close.
- In-app "Test setup": mic check + BlackHole loopback so routing can be verified without a real call.

Auto-detection:
- Wire MicMonitor into the GUI with an "Auto-detect calls" toggle and a "Call detected — start translation?" prompt (with anti-nag suppression).

Design:
- fluentai/ui/theme.py brand palette + helpers; restyled overlay and key buttons; lowercase "fluent ai" wordmark.

Docs/tests:
- docs/audio-routing.md, docs/design.md; roadmap updated (captions -> backlog).
- tests for audio_setup with CoreAudio mocked (incl. HTML-vs-pkg regression). Suite: 78 passed, 3 skipped; ruff clean.